### PR TITLE
Add basic wizbook prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@
 6. Instead, wizbook is expected to handle the mathematical relations between the variables of the UGC. For example, the weapons will be UGC but the weapon attack bonuses should be calculated automatically. However, you do NOT need to maintain the ruleset either. That will be UGC as well. So the user should be able to directly input (using dropdowns or a formal equation / expression langauge) how a weapon bonus is calculated.
 
 7. To start, the UI/UX should be absurdly simple. Linear boxes of features, left to right, top to down. The user should be able to "drag and drop" each box to order them.
+
+## Usage
+Open `index.html` in your browser. Use "Add Feature" to create a new feature box. Each feature can contain variables with numeric values or expressions referencing other variables using `FeatureName.variableName` syntax. Drag feature boxes to reorder them.

--- a/index.html
+++ b/index.html
@@ -1,12 +1,65 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wizbook</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 1rem;
+    }
+    #features {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .feature {
+      border: 1px solid #ccc;
+      padding: 0.5rem;
+      background: #f9f9f9;
+    }
+    .feature.dragging {
+      opacity: 0.5;
+    }
+    .variables {
+      margin-top: 0.5rem;
+    }
+    .variable {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 0.25rem;
+    }
+    .variable input[type="text"] {
+      flex: 1;
+    }
+    .variable span {
+      min-width: 40px;
+      text-align: right;
+    }
+  </style>
 </head>
 <body>
-  <h1>Hello, world!</h1>
-  <script src="script.js"></script>
+  <h1>Wizbook Prototype</h1>
+  <button id="addFeature">Add Feature</button>
+  <div id="features"></div>
+
+  <template id="featureTemplate">
+    <div class="feature" draggable="true">
+      <input class="feature-name" placeholder="Feature name" />
+      <button class="add-var">Add Variable</button>
+      <div class="variables"></div>
+    </div>
+  </template>
+
+  <template id="variableTemplate">
+    <div class="variable">
+      <input class="var-name" placeholder="name" />
+      <input class="var-expr" placeholder="expression or value" />
+      <span class="var-value"></span>
+    </div>
+  </template>
+
+<script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,1 +1,92 @@
-console.log("App loaded.");
+function $(sel, el = document) { return el.querySelector(sel); }
+function $$(sel, el = document) { return Array.from(el.querySelectorAll(sel)); }
+
+const featuresEl = $('#features');
+const featureTpl = $('#featureTemplate');
+const varTpl = $('#variableTemplate');
+
+$('#addFeature').addEventListener('click', () => {
+  addFeature();
+  evaluateAll();
+});
+
+function addFeature(data = {}) {
+  const node = featureTpl.content.firstElementChild.cloneNode(true);
+  $('.feature-name', node).value = data.name || '';
+  node.addEventListener('input', evaluateAll);
+  $('.add-var', node).addEventListener('click', () => {
+    addVariable(node);
+    evaluateAll();
+  });
+
+  node.addEventListener('dragstart', e => {
+    node.classList.add('dragging');
+    e.dataTransfer.effectAllowed = 'move';
+  });
+  node.addEventListener('dragend', () => node.classList.remove('dragging'));
+
+  featuresEl.appendChild(node);
+  return node;
+}
+
+function addVariable(featureEl, data = {}) {
+  const v = varTpl.content.firstElementChild.cloneNode(true);
+  $('.var-name', v).value = data.name || '';
+  $('.var-expr', v).value = data.expr || '';
+  v.addEventListener('input', evaluateAll);
+  $('.variables', featureEl).appendChild(v);
+  return v;
+}
+
+featuresEl.addEventListener('dragover', e => {
+  e.preventDefault();
+  const dragging = $('.dragging');
+  if (!dragging) return;
+  const after = Array.from(featuresEl.children).find(f => {
+    const rect = f.getBoundingClientRect();
+    return e.clientY < rect.top + rect.height / 2;
+  });
+  if (after) featuresEl.insertBefore(dragging, after);
+  else featuresEl.appendChild(dragging);
+});
+
+function evaluateAll() {
+  const features = {};
+  const order = [];
+  $$('.feature').forEach(f => {
+    const name = $('.feature-name', f).value.trim() || 'feature' + order.length;
+    order.push({name, el: f});
+    features[name] = {};
+  });
+  order.forEach(item => {
+    const {name, el} = item;
+    $$('.variable', el).forEach(v => {
+      const varName = $('.var-name', v).value.trim();
+      const expr = $('.var-expr', v).value.trim();
+      let val = parseFloat(expr);
+      if (isNaN(val)) {
+        val = evaluateExpression(expr, features);
+      }
+      if (!isFinite(val)) val = 0;
+      features[name][varName] = val;
+      $('.var-value', v).textContent = val;
+    });
+  });
+}
+
+function evaluateExpression(expr, feats) {
+  try {
+    const replaced = expr.replace(/([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)/g, (_, f, v) => {
+      return (feats[f] && v in feats[f]) ? feats[f][v] : 0;
+    });
+    return Function('Math', 'return Number(' + replaced + ')')(Math);
+  } catch(e) {
+    return 0;
+  }
+}
+
+// initial feature for convenience
+addFeature({name: 'Ability'});
+addVariable($('.feature'), {name: 'str', expr: '10'});
+evaluateAll();
+console.log('Wizbook loaded');


### PR DESCRIPTION
## Summary
- create a simple drag-and-drop interface for features
- allow variables with numeric or expression values referencing other features
- add minimal styling and templates
- document how to use the prototype

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887da176aa48331867d5a1d84f38cb1